### PR TITLE
Replaced display with visibility for performance

### DIFF
--- a/vanillaSelectBox.css
+++ b/vanillaSelectBox.css
@@ -5,7 +5,8 @@
 .vsb-menu{
   cursor:pointer;
   z-index:1000;
-  display:none;
+	display:block;
+	visibility: hidden;
   position:absolute;/*Don't change*/
   border:1px solid #B2B2B2;
   background-color: #fff;

--- a/vanillaSelectBox.js
+++ b/vanillaSelectBox.js
@@ -116,7 +116,7 @@ function vanillaSelectBox(domSelector, options) {
     this.closeOrder=function(){
         let self = this;
         if(!self.userOptions.stayOpen){
-            self.drop.style.display = "none";
+            self.drop.style.visibility = "hidden";
             if(self.search){
                 self.inputBox.value = "";
                 Array.prototype.slice.call(self.listElements).forEach(function (x) {
@@ -428,7 +428,7 @@ function vanillaSelectBox(domSelector, options) {
         }
 
 		if(self.userOptions.stayOpen){
-            self.drop.style.display = "block";
+            self.drop.style.visibility = "visible";
 			self.drop.style.boxShadow = "none";
 			self.drop.style.minHeight =  (this.userOptions.maxHeight+10) + "px";
 			self.drop.style.position = "relative";
@@ -440,7 +440,7 @@ function vanillaSelectBox(domSelector, options) {
 				if (self.isDisabled) return;
                     self.drop.style.left = self.left + "px";
                     self.drop.style.top = self.top + "px";
-                    self.drop.style.display = "block";
+                    self.drop.style.visibility = "visible";
                     document.addEventListener("click", docListener);
                     e.preventDefault();
                     e.stopPropagation();
@@ -540,7 +540,7 @@ function vanillaSelectBox(domSelector, options) {
         });
         function docListener() {
             document.removeEventListener("click", docListener);
-            self.drop.style.display = "none";
+            self.drop.style.visibility = "hidden";
             if(self.search){
                 self.inputBox.value = "";
                 Array.prototype.slice.call(self.listElements).forEach(function (x) {


### PR DESCRIPTION
Using visibility instead of display negates the recalculation of this stylesheet thus increasing performance when using thousands of dropdown items