### PR TITLE
Fix issue when selecting all the elements in a filtered list

### DIFF
--- a/vanillaSelectBox.js
+++ b/vanillaSelectBox.js
@@ -1156,6 +1156,7 @@ vanillaSelectBox.prototype.checkUncheckAll = function () {
     if (!self.isMultiple) return;
     let nrChecked = 0;
     let nrCheckable = 0;
+    let totalAvailableElements = 0;
     let checkAllElement = null;
     if (self.listElements == null) return;
     Array.prototype.slice.call(self.listElements).forEach(function (x) {
@@ -1169,13 +1170,19 @@ vanillaSelectBox.prototype.checkUncheckAll = function () {
                 nrCheckable++;
                 nrChecked += x.classList.contains('active');
             }
+            if (x.getAttribute('data-value') !== 'all'
+                && !x.classList.contains('disabled')) {
+                totalAvailableElements++;
+            }
         }
     });
 
     if (checkAllElement) {
         if (nrChecked === nrCheckable) {
             // check the checkAll checkbox
-            self.title.textContent = self.userOptions.translations.all;
+            if (nrChecked === totalAvailableElements) {
+                self.title.textContent = self.userOptions.translations.all;
+            }
             checkAllElement.classList.add("active");
             checkAllElement.innerText = self.userOptions.translations.clearAll;
             checkAllElement.setAttribute('data-selected', 'true')


### PR DESCRIPTION
Hi @PhilippeMarcMeyer ,we used your library on our project, just detected one minor issue, i will describe it below, thanks in advance.

- Issue: if you select all the elements when the list is filtered by the textBox it will put the value All to the placeholder even when it does not have all the values selected, if you close and open again the select you will notice that not all the values are checked and the placeholder says All

- Steps to reproduce:
 1) In the Demo use The All Selected test element
 2) Uncheck all the elements
 3) Use a word to filter the list
 4) Select all the elements filtered using the check all option or selecting the option directly
 5) Close the dropdown or erase the filter value