### PR TITLE
Fix bug for selection after filter

### DIFF
--- a/vanillaSelectBox.js
+++ b/vanillaSelectBox.js
@@ -561,7 +561,7 @@ function vanillaSelectBox(domSelector, options) {
                             selectAll.classList.remove("active");
                             selectAll.innerText = self.userOptions.translations.selectAll;
                             selectAll.setAttribute('data-selected', 'false')
-                        } else {
+                        } else if (nrChecked == self.listElements.length) {
                             selectAll.classList.add("active");
                             selectAll.innerText = self.userOptions.translations.clearAll;
                             selectAll.setAttribute('data-selected', 'true')
@@ -1184,10 +1184,10 @@ vanillaSelectBox.prototype.checkUncheckAll = function () {
             // check the checkAll checkbox
             if (nrChecked === totalAvailableElements) {
                 self.title.textContent = self.userOptions.translations.all;
-            }
-            checkAllElement.classList.add("active");
-            checkAllElement.innerText = self.userOptions.translations.clearAll;
-            checkAllElement.setAttribute('data-selected', 'true')
+                checkAllElement.classList.add("active");
+                checkAllElement.innerText = self.userOptions.translations.clearAll;
+                checkAllElement.setAttribute('data-selected', 'true')
+            }            
         } else if (nrChecked === 0) {
             // uncheck the checkAll checkbox
             self.title.textContent = self.userOptions.placeHolder;


### PR DESCRIPTION
> if you select all the elements when the list is filtered by the textBox it will put the value All to the placeholder even when it does not have all the values selected, if you close and open again the select you will notice that not all the values are checked and the placeholder says All

If I understand correctly, I think it may related to line 1185 of vanillaSelectBox.js.
https://github.com/PhilippeMarcMeyer/vanillaSelectBox/blob/540f6bd7677cbc892dd52018cc70e12360271e7e/vanillaSelectBox.js#L1185-L1190
```
checkAllElement.classList.add("active");
checkAllElement.innerText = self.userOptions.translations.clearAll;
checkAllElement.setAttribute('data-selected', 'true')
```
this code snippet should wrap inside `if (nrChecked === totalAvailableElements)`. Because the checkAll checkbox should checked if the selected element length equal to the available elements length instead of Checkable length.

Also line 564
https://github.com/PhilippeMarcMeyer/vanillaSelectBox/blob/540f6bd7677cbc892dd52018cc70e12360271e7e/vanillaSelectBox.js#L564-L568
I think selectAll should change to clearAll if the selected element length equal to the available elements length. 
